### PR TITLE
Update HCL grammer

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1829,7 +1829,7 @@ auto-format = true
 
 [[grammar]]
 name = "hcl"
-source = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "3cb7fc28247efbcb2973b97e71c78838ad98a583" }
+source = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "9e3ec9848f28d26845ba300fd73c740459b83e9b" }
 
 [[language]]
 name = "tfvars"


### PR DESCRIPTION
Updates the Tree-Sitter grammar to the newest version available in the repository.

The main motivation is to support provider-defined function calls in Terraform, as implemented on the repository in https://github.com/tree-sitter-grammars/tree-sitter-hcl/pull/51

I have tested this locally with my `helix 24.7 (079f5442)` by

1. Changing my own `languages.toml` file to point to the new Git ref
2. Fetching grammars via `hx -g fetch`
3. Building the grammar via `hx -g build`
4. Verifying with a test terraform file that the syntax is displayed correctly again

A simple test file:

```hcl
terraform {
  required_providers {
    netparse = {
      source = "gmeligio/netparse"
      version = "0.0.2"
    }
  }
}

output "testing" {
  value = provider::netparse::parse_url("https://test.page/hello?world=true")
}
```